### PR TITLE
remove jQuery reference in getCanvasData using existing each method

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -475,14 +475,14 @@
       var data = {};
 
       if (this.built) {
-        $.each([
+        each([
           'left',
           'top',
           'width',
           'height',
           'naturalWidth',
           'naturalHeight'
-        ], function (i, n) {
+        ], function (n) {
           data[n] = canvasData[n];
         });
       }


### PR DESCRIPTION
This fixes the `$ is not defined error` when getCanvasData is called.

This doesn't happen in the demo because jQuery is available.