### PR TITLE
Add related projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,4 +1018,9 @@ Maintained under the [Semantic Versioning guidelines](http://semver.org/).
 [MIT](http://opensource.org/licenses/MIT) © [Fengyuan Chen](http://chenfengyuan.com)
 
 
+
+## Related projects
+
+- [react-cropperjs](https://github.com/TAPP-TV/react-cropperjs) by @pbojinov
+
 [⬆ back to top](#table-of-contents)


### PR DESCRIPTION
Similar to how the [cropper](https://github.com/fengyuanchen/cropper) repo has related projects, add [react-cropperjs](https://github.com/TAPP-TV/react-cropperjs) under the related projects section at the bottom of the README. Adding it to the related projects section increases the reach of the cropperjs project.

react-cropperjs wraps cropperjs and provides an interface to React apps wanting to utilize the cropper without a jQuery depedency.