### PR TITLE
Fixed `replace()` without `autoCrop` crash

### DIFF
--- a/src/js/cropper.js
+++ b/src/js/cropper.js
@@ -333,6 +333,7 @@ class Cropper {
         $.addClass(dragBox, 'cropper-modal');
       }
     } else {
+      self.cropped = false;
       $.addClass(cropBox, CLASS_HIDDEN);
     }
 

--- a/test/methods/replace.js
+++ b/test/methods/replace.js
@@ -3,17 +3,20 @@ QUnit.test('methods#replace', function (assert) {
   var util = window.Util;
   var image = util.createImage();
 
-  assert.expect(1);
+  assert.expect(2);
 
   return new Cropper(image, {
     ready: function () {
       var cropper = this.cropper;
 
       cropper.options.ready = function () {
-        assert.ok(true);
+        assert.notOk(cropper.cropped);
+        cropper.crop();
+        assert.ok(cropper.cropped);
         done();
       };
 
+      cropper.options.autoCrop = false;
       cropper.replace('../assets/images/picture-2.jpg');
     }
   });


### PR DESCRIPTION
UI was not being refreshed by `crop()` after a `replace()` because `cropped` was not being reset to `false`.

`autoCrop` had worked okay because it doesn't care about `cropped`.

I hope the new test for `replace` is okay.

Fixes #83.