### PR TITLE
Fix timestamp issue

### DIFF
--- a/src/js/cropper.js
+++ b/src/js/cropper.js
@@ -145,7 +145,7 @@ class Cropper {
       this.read(xhr.response);
     };
 
-    if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin) {
+    if (options.checkCrossOrigin && isCrossOriginURL(url) && !element.crossOrigin) {
       url = addTimestamp(url);
     }
 


### PR DESCRIPTION
In the docs it is written, that adding timestamps to url can be disabled by adding crossOrigin to cropper's img. But it didn't work, cause in load instead of checking that crossOrigin is not set, you checked whether is set... so timestamp was always added. This is a fix for that, making it possible to disable adding timestamp.
  