### PR TITLE
Touch-action attribute for pointer event polyfill compatibility

### DIFF
--- a/src/js/template.js
+++ b/src/js/template.js
@@ -1,5 +1,5 @@
 export default (
-  '<div class="cropper-container">' +
+  '<div class="cropper-container" touch-action="none">' +
     '<div class="cropper-wrap-box">' +
       '<div class="cropper-canvas"></div>' +
     '</div>' +


### PR DESCRIPTION
We use the popular [jquery/PEP](https://github.com/jquery/pep) as polyfill for the pointer events API. When using this API cropperjs does not respond anymore on touch devices that require this polyfill.

Normally the touch-action CSS property (used on cropper-container) will trigger the pointer events when the browser natively supports it. The polyfill cannot use this property easily since the browser does not actually support it, will throw it out and make it impossible to read it in the polyfill code. To resolve this many pointer event polyfills use a custom attribute (`touch-action=".."`) on the html element instead. If this attribute is not present, no pointer events are triggered (similar to the CSS property).

Because cropperjs switches to pointer events if the PointerEvent class is present and this is the case with the polyfill, but the html attribute is not set it will never receive any events.

An easy fix is to add the touch-action attribute to the cropper-container div. This makes the library compatible with the polyfill.