### PR TITLE
fix(package): remove browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.3.0",
   "main": "dist/cropper.common.js",
   "module": "dist/cropper.esm.js",
-  "browser": "dist/cropper.js",
   "types": "types/index.d.ts",
   "style": "dist/cropper.css",
   "repository": "fengyuanchen/cropperjs",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](CONTRIBUTING.md#commit-message-guidelines).
- n/a Tests for the changes have been added (for bug fixes / features)
- n/a Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[x] Build related changes
[ ] Documentation content changes
[ ] Other, Please describe:
```


## What is the current behavior?

Tools like webpack currently pick the bundle from the `browser` field over the bundles in `main` or `module`. This happens because including the `browser` field means that the `main` and `module` bundles are meant for use with Node, and the `browser` bundle is meant for use in browsers. See the [package browser field spec](https://github.com/defunctzombie/package-browser-field-spec). `cropperjs` does not have separate builds for browser use, so including this field is incorrect.

If you need to use the commonjs or esm bundle it is currently needed to import it directly, as the bundler will always choose the `browser` build.

```ts
import Cropper from 'cropperjs/dist/cropper.esm.js';
```

## What is the new behavior?

Importing Just Works ™️. The bundler chooses the `main` or `module` build, whichever it prefers.

```ts
import Cropper from 'cropperjs';
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Related #305