### PR TITLE
fix: TS definitions - Add missing pivot to zoomTo

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -168,7 +168,7 @@ declare class Cropper {
   setData(data: Cropper.SetDataOptions): Cropper;
   setDragMode(dragMode: Cropper.DragMode): Cropper;
   zoom(ratio: number): Cropper;
-  zoomTo(ratio: number): Cropper;
+  zoomTo(ratio: number, pivot?: {x: number; y: number}): Cropper;
 }
 
 declare module 'cropperjs' {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/fengyuanchen/cropperjs/blob/master/.github/CONTRIBUTING.md#commit-message-guidelines).
- n/a [ ] Tests for the changes have been added (for bug fixes / features)
- n/a  [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[ ] Build related changes
[ ] Documentation content changes
[x] Other, Please describe: Typescript definitions update
```


## What is the current behavior?

TypeScript definitions for zoomTo does not accept optional param pivot.
Issue Number: N/A


## What is the new behavior?

zoomTo now accepts optional param pivot.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
