### PR TITLE
fix: crop box overflows in "viewMode" 1 and 2

### DIFF
--- a/src/js/render.js
+++ b/src/js/render.js
@@ -366,14 +366,28 @@ export default {
     if (sizeLimited) {
       let minCropBoxWidth = Number(options.minCropBoxWidth) || 0;
       let minCropBoxHeight = Number(options.minCropBoxHeight) || 0;
-      let maxCropBoxWidth = Math.min(
-        containerData.width,
-        limited ? canvasData.width : containerData.width,
-      );
-      let maxCropBoxHeight = Math.min(
-        containerData.height,
-        limited ? canvasData.height : containerData.height,
-      );
+      let maxCropBoxWidth = containerData.width;
+      let maxCropBoxHeight = containerData.height;
+
+      if (limited) {
+        const canvasRight = containerData.width - canvasData.left - canvasData.width;
+        const canvasBottom = containerData.height - canvasData.top - canvasData.height;
+
+        maxCropBoxWidth = Math.min(
+          containerData.width,
+          Math.min(
+            canvasData.width,
+            canvasData.width + (canvasRight < 0 ? canvasRight : canvasData.left),
+          ),
+        );
+        maxCropBoxHeight = Math.min(
+          containerData.height,
+          Math.min(
+            canvasData.height,
+            canvasData.height + (canvasBottom < 0 ? canvasBottom : canvasData.top),
+          ),
+        );
+      }
 
       // The min/maxCropBoxWidth/Height must be less than container's width/height
       minCropBoxWidth = Math.min(minCropBoxWidth, containerData.width);

--- a/test/specs/options/viewMode.spec.js
+++ b/test/specs/options/viewMode.spec.js
@@ -28,11 +28,55 @@ describe('viewMode (option)', () => {
       viewMode: 1,
 
       ready() {
-        const canvasData = cropper.zoom(-0.5).getCanvasData();
-        const cropBoxData = cropper.getCropBoxData();
+        let canvasData = cropper.zoom(-0.5).getCanvasData();
+        let cropBoxData = cropper.getCropBoxData();
 
         expect(canvasData.width).to.be.least(cropBoxData.width);
         expect(canvasData.height).to.be.least(cropBoxData.height);
+
+        // Move the canvas beyond the top and left container boundaries
+        canvasData = cropper.zoom(0.5).setCropBoxData({
+          left: 0,
+          top: 0,
+          width: 10,
+          height: 10,
+        }).moveTo(-200).getCanvasData();
+
+        expect(canvasData.left).to.be.equal(-200);
+        expect(canvasData.top).to.be.equal(-200);
+
+        cropBoxData = cropper.setCropBoxData({
+          width: canvasData.width,
+          height: canvasData.height,
+        }).getCropBoxData();
+
+        expect(cropBoxData.width).to.be.equal(canvasData.width + canvasData.left);
+        expect(cropBoxData.height).to.be.equal(canvasData.height + canvasData.top);
+
+        // Move the canvas beyond the bottom and right container boundaries
+        canvasData = cropper.setCropBoxData({
+          left: cropBoxData.width,
+          top: cropBoxData.height,
+          width: 10,
+          height: 10,
+        }).move(500).getCanvasData();
+
+        const canvasRight = cropper.getContainerData().width - canvasData.left - canvasData.width;
+        const canvasBottom = cropper.getContainerData().height - canvasData.top - canvasData.height;
+
+        expect(canvasData.left).to.be.least(1);
+        expect(canvasData.top).to.be.least(1);
+        expect(canvasRight).to.be.below(0);
+        expect(canvasBottom).to.be.below(0);
+
+        cropBoxData = cropper.setCropBoxData({
+          width: canvasData.width,
+          height: canvasData.height,
+        }).getCropBoxData();
+
+        expect(cropBoxData.width).to.be.equal(canvasData.width + canvasRight);
+        expect(cropBoxData.height).to.be.equal(canvasData.height + canvasBottom);
+
         done();
       },
     });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our [guidelines](https://github.com/fengyuanchen/cropperjs/blob/master/.github/CONTRIBUTING.md#commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)


## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[ ] Build related changes
[ ] Documentation content changes
[ ] Other, Please describe:
```


## What is the current behavior?

When using "viewMode" 1 or 2, the crop box could overflow if the canvas is moved partly beyond the container boundaries.

If moved beyond the top/left boundaries, it could overflow the container. If moved beyond the bottom/right boundaries, it could overflow the canvas (exceeding its size).

This behavior can be reproduced on the demo page:
https://fengyuanchen.github.io/cropperjs/

Steps to reproduce:

1. In "viewMode" 1 or 2 drag mode, switch to using "free" aspect ratio
2. Drag the image beyond the top/left or bottom/right container boundaries
3. Use "setData" with width/height values greater than the image
(e.g. `{"width":2000,"height":3000}`)

I could also reproduce it in aspect ratio mode, for example:

1. In "viewMode" 1 or 2, switch to using "4:3" aspect ratio
2. Drag the image beyond the top/left container boundaries
3. Move the crop box to the top left position
4. Use the "se" drag handle and drag it down


## What is the new behavior?

In limited "viewMode", if the image canvas is moved beyond the boundaries of the container, it is prevented to inadvertently have the crop box overflow the boundaries of the container or image canvas when using the crop box drag handles or `setData`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

First of all, thank you for Cropper.js!

We ran into this problem when testing our use case where we have input fields to set the desired width/height of the image. The code changes in this PR (tested carefully) should fix it.