### PR TITLE
perf: don't recompute the DataUrl if it is already known

### DIFF
--- a/src/js/cropper.js
+++ b/src/js/cropper.js
@@ -117,7 +117,7 @@ class Cropper {
     // XMLHttpRequest disallows to open a Data URL in some browsers like IE11 and Safari
     if (REGEXP_DATA_URL.test(url)) {
       if (REGEXP_DATA_URL_JPEG.test(url)) {
-        this.read(dataURLToArrayBuffer(url));
+        this.read(dataURLToArrayBuffer(url), url);
       } else {
         this.clone();
       }
@@ -158,7 +158,7 @@ class Cropper {
     xhr.send();
   }
 
-  read(arrayBuffer) {
+  read(arrayBuffer, urlIfKnown) {
     const { options, imageData } = this;
     const orientation = getOrientation(arrayBuffer);
     let rotate = 0;
@@ -166,7 +166,11 @@ class Cropper {
     let scaleY = 1;
 
     if (orientation > 1) {
-      this.url = arrayBufferToDataURL(arrayBuffer, 'image/jpeg');
+      if (urlIfKnown) {
+        this.url = urlIfKnown;
+      } else {
+        this.url = arrayBufferToDataURL(arrayBuffer, 'image/jpeg');
+      }
       ({ rotate, scaleX, scaleY } = parseOrientation(orientation));
     }
 


### PR DESCRIPTION
This change improves performance when a JPEG image is loaded from a
data url and checkOrientation is set to true. Before this change, the
image was converted into a byte array and then it was converted back
into a data url, without being modified between the two steps. After
this change, we will just reuse the original data url instead of
converting the byte array back. (This saves ~1secs on my laptop with
large photos.)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](https://github.com/fengyuanchen/cropperjs/blob/master/.github/CONTRIBUTING.md#commit-message-guidelines).
- [n.a.] Tests for the changes have been added (for bug fixes / features)
- [n.a.] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[ ] Build related changes
[ ] Documentation content changes
[X] Other, Please describe: performance improvement
```


## What is the current behavior?

When a JPEG image is loaded from a data url and checkOrientation is set to true, the image is converted into a byte array and then it was converted back into a data url, without being modified between the two steps.

Issue Number: N/A

## What is the new behavior?

We will just reuse the original data url instead of converting the byte array back. (This saves ~1secs on my laptop with large photos.)


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


