### PR TITLE
perf: add characters in chunks in dataURLToArrayBuffer

### DIFF
--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -802,19 +802,12 @@ export function dataURLToArrayBuffer(dataURL) {
 export function arrayBufferToDataURL(arrayBuffer, mimeType) {
   const uint8 = new Uint8Array(arrayBuffer);
   let data = '';
-
-  // TypedArray.prototype.forEach is not supported in some browsers as IE.
-  if (isFunction(uint8.forEach)) {
-    // Use native `forEach` method first for better performance
-    uint8.forEach((value) => {
-      data += fromCharCode(value);
-    });
-  } else {
-    forEach(uint8, (value) => {
-      data += fromCharCode(value);
-    });
-  }
-
+  // Rather than adding characters one-by-one to data, we add them in chunks.
+  // This improves speed.
+  let CHUNK_SIZE = 4096;
+  for (let i = 0; i < uint8.length; i += CHUNK_SIZE) {
+    data += String.fromCharCode.apply(null, uint8.slice(i, i + CHUNK_SIZE));
+  };
   return `data:${mimeType};base64,${btoa(data)}`;
 }
 


### PR DESCRIPTION
This change improves performance when a JPEG image is loaded from a
data url and `checkOrientation` is set to true. Before this change,
the `data` string was built by adding characters one by one. After
this change, the characers will be added in chunks.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/fengyuanchen/cropperjs/blob/master/.github/CONTRIBUTING.md#commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[ ] Build related changes
[ ] Documentation content changes
[X] Other, Please describe: performance improvement
```


## What is the current behavior?

The behavior is unchanged.

Issue Number: N/A


## What is the new behavior?

The behavior is unchanged.


## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Here is some example code that demonstrates the speedup:
```
// Generate test data.
var tmp = []; for (var i = 0; i < 8 * 1000 * 1000; ++i) tmp.push((i % 10) + 50);
var src = new Uint8Array(tmp);

// Try building a string with various chunk sizes.
for (var chunkSize = 1; chunkSize < 65536; chunkSize *= 2) {
  var t1 = performance.now();
  var s = '';
  for (var i = 0; i < src.length; i += chunkSize) {
    if (chunkSize == 1) {
      s += String.fromCharCode(src[i]);
    } else {
      s += String.fromCharCode.apply(null, src.slice(i, i + chunkSize));
    }
  };
  console.log('control:', s.length, s[s.length-1]);
  console.log('chunk size:', chunkSize, 'time:', performance.now() - t1);
}
```


