### PR TITLE
Fix the TS types for the drag mode, smoothing quality and view mode options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,22 +1,14 @@
 declare namespace Cropper {
-  enum DragMode {
-    Crop = 'crop',
-    Move = 'move',
-    None = 'none',
-  }
+  type DragMode = 'crop' | 'move' | 'none';
 
-  enum ViewMode {
+  const enum ViewMode {
     Free = 0,
     CanvasWidthAndHeightShouldNotBeLessThanCropBoxSize = 1,
     CanvasWidthOrHeightShouldNotBeLessThanContainerSize = 2,
     CanvasWidthAndHeightShouldNotBeLessThanContainerSize = 3,
   }
 
-  enum ImageSmoothingQuality {
-    Low = 'low',
-    Medium = 'medium',
-    High = 'high',
-  }
+  type ImageSmoothingQuality = 'low' | 'medium' | 'high';
 
   export interface Data {
     x: number;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No (to be confirmed by some typescript user)

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**

The enums don't exist at runtime (as the source code does not have them as it is not TS). So declaring them as enum causes issues. I got tsc warnings when trying to run it to check the JS code. Passing `move` explicitly was not considered as a valid value for the `drag` option.

String enums are replaced with a union of literal types. The ViewMode is turned into a const enum so that typescript will inline the numbers during compilation instead of trying to access them on an object.

The switch from enum to a union of literals should be checked by TS users to see whether it breaks BC (but I think it was not working at all before).

