### PR TITLE
fix #535 Added an option shouldBustCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,15 @@ Restore the cropped area after resizing the window.
 
 Check if the current image is a cross-origin image.
 
-If it is, when clone the image, a `crossOrigin` attribute will be added to the cloned image element and a timestamp will be added to the `src` attribute to reload the source image to avoid browser cache error.
+If it is, when clone the image, a `crossOrigin` attribute will be added to the cloned image element and a timestamp will be added to the `src` attribute to reload the source image to avoid browser cache error. (Sending the timestamp parameter can be supressed if needed, see the shouldBustCache option)
 
-By adding `crossOrigin` attribute to image element will stop adding timestamp to image URL and stop reload of image, but the request (XMLHttpRequest) to read the image data for orientation checking will require a timestamp to bust cache to avoid browser cache error now, you can set the `checkOrientation` option to `false` to cancel this request.
+By adding `crossOrigin` attribute to image element will stop adding timestamp to image URL and stop reload of image, but the request (XMLHttpRequest) to read the image data for orientation checking will require a timestamp to bust cache to avoid browser cache error now, you can set the `checkOrientation` option to `false` to cancel this request. (Sending the timestamp parameter can be supressed if needed, see the shouldBustCache option)
 
 If the value of the image's `crossOrigin` attribute is `"use-credentials"`, then the `withCredentials` attribute will set to `true` when read the image data by XMLHttpRequest.
+
+### shouldBustCache
+
+If for some reason the extra timestamp query parameter should not be sent to the server you can suppress this behavior by setting the shouldBustCache option to false. This can be the case when for example the urls used are signed for example for use with AWS CloudFront or AWS S3. This could result in the cache not being busted though for some browser.
 
 ### checkOrientation
 

--- a/src/js/cropper.js
+++ b/src/js/cropper.js
@@ -163,7 +163,7 @@ class Cropper {
     };
 
     // Bust cache when there is a "crossOrigin" property to avoid browser cache error
-    if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin) {
+    if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin && options.shouldBustCache) {
       url = addTimestamp(url);
     }
 
@@ -214,7 +214,9 @@ class Cropper {
       }
 
       // Bust cache when there is not a "crossOrigin" property (#519)
-      crossOriginUrl = addTimestamp(url);
+      if (this.options.shouldBustCache) {
+        crossOriginUrl = addTimestamp(url);
+      }
     }
 
     this.crossOrigin = crossOrigin;

--- a/src/js/cropper.js
+++ b/src/js/cropper.js
@@ -163,7 +163,8 @@ class Cropper {
     };
 
     // Bust cache when there is a "crossOrigin" property to avoid browser cache error
-    if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin && options.shouldBustCache) {
+    if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin 
+      && options.shouldBustCache) {
       url = addTimestamp(url);
     }
 

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -28,6 +28,9 @@ export default {
   // Check if the current image is a cross-origin image
   checkCrossOrigin: true,
 
+  // Prevent cache busting to happen
+  shouldBustCache: true,
+
   // Check the current image's Exif Orientation information
   checkOrientation: true,
 
@@ -89,7 +92,7 @@ export default {
   minCropBoxHeight: 0,
   minContainerWidth: 200,
   minContainerHeight: 100,
-
+  
   // Shortcuts of events
   ready: null,
   cropstart: null,

--- a/test/specs/options/shouldBustCache.spec.js
+++ b/test/specs/options/shouldBustCache.spec.js
@@ -1,0 +1,20 @@
+describe('shouldBustCache (option)', () => {
+  const crossOriginImageURL = 'https://fengyuanchen.github.io/cropperjs/images/picture.jpg';
+
+  it('should not add timestamp when shouldBustCache = false', (done) => {
+    const image = window.createImage({
+      src: crossOriginImageURL,
+    });
+    const shouldBustCache = false;
+    const cropper = new Cropper(image, {
+      shouldBustCache,
+      ready() {
+        expect(cropper.image.crossOrigin).to.equal('anonymous');
+        expect(cropper.image.src).to.not.include('timestamp');
+        done();
+      },
+    });
+
+    expect(cropper.options.checkCrossOrigin).to.be.true;
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,6 +90,7 @@ declare namespace Cropper {
     background?: boolean;
     center?: boolean;
     checkCrossOrigin?: boolean;
+    shouldBustCache?: boolean;
     checkOrientation?: boolean;
     crop?(event: CustomEvent): void;
     cropBoxMovable?: boolean;


### PR DESCRIPTION
**Summary**

Added an option shouldBustCache to prevent code from adding a timestamp for cache busting. Since this will cripple implementations where custom query parameters are not allowed. Fixes #535 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

**Other information:**

Added a unit test to verify the option is working as expected.