### PR TITLE
fix: IS_TOUCH_DEVICE

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -1,6 +1,6 @@
 export const IS_BROWSER = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 export const WINDOW = IS_BROWSER ? window : {};
-export const IS_TOUCH_DEVICE = IS_BROWSER ? 'ontouchstart' in WINDOW.document.documentElement : false;
+export const IS_TOUCH_DEVICE = IS_BROWSER && WINDOW.document.documentElement ? 'ontouchstart' in WINDOW.document.documentElement : false;
 export const HAS_POINTER_EVENT = IS_BROWSER ? 'PointerEvent' in WINDOW : false;
 export const NAMESPACE = 'cropper';
 


### PR DESCRIPTION
Upgrading from 1.0.0-rc.3 to 1.5.0+ makes the page crashed: 
`TypeError: Cannot use 'in' operator to search for 'ontouchstart' in null`

user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.91 Safari/537.36 

The error points to this change:
https://github.com/fengyuanchen/cropperjs/commit/b78625f9ff4d5c2dd0dd34311f7c0e8d5211afaf#diff-6a721e8e6aa7d4dc81e0a3610e25ce44R3

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Could you release a new v1 version as soon as possible, since fork & publish is a little troublesome?