### PR TITLE
export additional types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace Cropper {
-  type DragMode = 'crop' | 'move' | 'none';
-  type ViewMode = 0 | 1 | 2 | 3;
-  type ImageSmoothingQuality = 'low' | 'medium' | 'high';
+  export type DragMode = 'crop' | 'move' | 'none';
+  export type ViewMode = 0 | 1 | 2 | 3;
+  export type ImageSmoothingQuality = 'low' | 'medium' | 'high';
 
   export interface Data {
     x: number;


### PR DESCRIPTION
**Summary**

Export additional types so we can reference them. When using multiple croppers and wanting to share some base props, it's not possible to set things such as `viewMode` without duplicating the type constraint because the `ViewMode` type is not exported, so we cannot use it directly, and `number` is not assignable to `ViewMode`.

```
const cropperProps = { viewMode: 1 };

<Cropper {...cropperProps} aspectRatio={1} />
<Cropper {...cropperProps} aspectRatio={4 / 3} />
```

**What kind of change does this PR introduce?**

- [ x ] Bugfix (types only)
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** ho

- [ ] Yes
- [ x ] No

**The PR fulfills these requirements:**

N/A -- type fix only
