### PR TITLE
Add prop for height ration derived from calculated width of cropper container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.map
 coverage
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ Define the initial aspect ratio of the crop box. By default, it is the same as t
 
 Define the fixed aspect ratio of the crop box. By default, the crop box is free ratio.
 
+### containerHeightAspectRatio
+
+- Type: `Number`
+- Default: `NaN`
+
+Define a ratio between the width of the container for cropper and the height. If you set `auto`, `aspectRatio` is used.
+
 ### data
 
 - Type: `Object`

--- a/dist/cropper.common.js
+++ b/dist/cropper.common.js
@@ -1,11 +1,11 @@
 /*!
- * Cropper.js v1.5.9
+ * Cropper.js v1.5.10
  * https://fengyuanchen.github.io/cropperjs
  *
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-09-10T13:16:26.743Z
+ * Date: 2020-10-19T21:08:46.621Z
  */
 
 'use strict';
@@ -1223,13 +1223,17 @@ var render = {
         options = this.options,
         container = this.container,
         cropper = this.cropper;
+    var aspectRatio = options.aspectRatio,
+        containerHeightAspectRatio = options.containerHeightAspectRatio;
     var minWidth = Number(options.minContainerWidth);
     var minHeight = Number(options.minContainerHeight);
+    var heightAspectRatio = containerHeightAspectRatio === 'auto' ? aspectRatio : containerHeightAspectRatio;
     addClass(cropper, CLASS_HIDDEN);
     removeClass(element, CLASS_HIDDEN);
+    var containerWidth = Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH);
     var containerData = {
-      width: Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH),
-      height: Math.max(container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
+      width: containerWidth,
+      height: Math.max(heightAspectRatio ? containerWidth / heightAspectRatio : container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
     };
     this.containerData = containerData;
     setStyle(cropper, {
@@ -3334,9 +3338,10 @@ var Cropper = /*#__PURE__*/function () {
 
       if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin) {
         url = addTimestamp(url);
-      }
+      } // The third parameter is required for avoiding side-effect (#682)
 
-      xhr.open('GET', url);
+
+      xhr.open('GET', url, true);
       xhr.responseType = 'arraybuffer';
       xhr.withCredentials = element.crossOrigin === 'use-credentials';
       xhr.send();

--- a/dist/cropper.common.js
+++ b/dist/cropper.common.js
@@ -1247,11 +1247,14 @@ var render = {
   initCanvas: function initCanvas() {
     var containerData = this.containerData,
         imageData = this.imageData;
-    var viewMode = this.options.viewMode;
+    var _this$options = this.options,
+        viewMode = _this$options.viewMode,
+        optionAspectRatio = _this$options.aspectRatio,
+        containerHeightAspectRatio = _this$options.containerHeightAspectRatio;
     var rotated = Math.abs(imageData.rotate) % 180 === 90;
     var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
     var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-    var aspectRatio = naturalWidth / naturalHeight;
+    var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
     var canvasWidth = containerData.width;
     var canvasHeight = containerData.height;
 

--- a/dist/cropper.common.js
+++ b/dist/cropper.common.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T14:11:23.958Z
+ * Date: 2021-08-30T19:53:23.812Z
  */
 
 'use strict';
@@ -1254,9 +1254,13 @@ var render = {
     var rotated = Math.abs(imageData.rotate) % 180 === 90;
     var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
     var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-    var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
     var canvasWidth = containerData.width;
     var canvasHeight = containerData.height;
+    var aspectRatio = naturalWidth / naturalHeight;
+
+    if (viewMode === 0 && containerHeightAspectRatio === 'auto') {
+      aspectRatio = optionAspectRatio;
+    }
 
     if (containerData.height * aspectRatio > containerData.width) {
       if (viewMode === 3) {

--- a/dist/cropper.common.js
+++ b/dist/cropper.common.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-10-19T21:08:46.621Z
+ * Date: 2021-06-09T20:46:10.047Z
  */
 
 'use strict';
@@ -1380,7 +1380,10 @@ var render = {
   },
   renderCanvas: function renderCanvas(changed, transformed) {
     var canvasData = this.canvasData,
-        imageData = this.imageData;
+        imageData = this.imageData,
+        options = this.options;
+    var optionAspectRatio = options.aspectRatio,
+        containerHeightAspectRatio = options.containerHeightAspectRatio;
 
     if (transformed) {
       var _getRotatedSizes = getRotatedSizes({
@@ -1397,7 +1400,7 @@ var render = {
       canvasData.top -= (height - canvasData.height) / 2;
       canvasData.width = width;
       canvasData.height = height;
-      canvasData.aspectRatio = naturalWidth / naturalHeight;
+      canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
       canvasData.naturalWidth = naturalWidth;
       canvasData.naturalHeight = naturalHeight;
       this.limitCanvas(true, false);

--- a/dist/cropper.common.js
+++ b/dist/cropper.common.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T13:54:54.192Z
+ * Date: 2021-06-10T14:11:23.958Z
  */
 
 'use strict';
@@ -1272,8 +1272,8 @@ var render = {
 
     var canvasData = {
       aspectRatio: aspectRatio,
-      naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
-      naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
+      naturalWidth: naturalWidth,
+      naturalHeight: naturalHeight,
       width: canvasWidth,
       height: canvasHeight
     };

--- a/dist/cropper.common.js
+++ b/dist/cropper.common.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-09T20:46:10.047Z
+ * Date: 2021-06-10T13:54:54.192Z
  */
 
 'use strict';
@@ -1272,8 +1272,8 @@ var render = {
 
     var canvasData = {
       aspectRatio: aspectRatio,
-      naturalWidth: naturalWidth,
-      naturalHeight: naturalHeight,
+      naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
+      naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
       width: canvasWidth,
       height: canvasHeight
     };
@@ -1380,10 +1380,7 @@ var render = {
   },
   renderCanvas: function renderCanvas(changed, transformed) {
     var canvasData = this.canvasData,
-        imageData = this.imageData,
-        options = this.options;
-    var optionAspectRatio = options.aspectRatio,
-        containerHeightAspectRatio = options.containerHeightAspectRatio;
+        imageData = this.imageData;
 
     if (transformed) {
       var _getRotatedSizes = getRotatedSizes({
@@ -1400,7 +1397,7 @@ var render = {
       canvasData.top -= (height - canvasData.height) / 2;
       canvasData.width = width;
       canvasData.height = height;
-      canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
+      canvasData.aspectRatio = naturalWidth / naturalHeight;
       canvasData.naturalWidth = naturalWidth;
       canvasData.naturalHeight = naturalHeight;
       this.limitCanvas(true, false);

--- a/dist/cropper.css
+++ b/dist/cropper.css
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-09T20:46:05.527Z
+ * Date: 2021-06-10T13:54:47.349Z
  */
 
 .cropper-container {

--- a/dist/cropper.css
+++ b/dist/cropper.css
@@ -1,11 +1,11 @@
 /*!
- * Cropper.js v1.5.9
+ * Cropper.js v1.6.0
  * https://fengyuanchen.github.io/cropperjs
  *
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-09-10T13:16:21.689Z
+ * Date: 2020-10-08T18:19:48.200Z
  */
 
 .cropper-container {

--- a/dist/cropper.css
+++ b/dist/cropper.css
@@ -1,5 +1,5 @@
 /*!
- * Cropper.js v1.6.0
+ * Cropper.js v1.5.10
  * https://fengyuanchen.github.io/cropperjs
  *
  * Copyright 2015-present Chen Fengyuan

--- a/dist/cropper.css
+++ b/dist/cropper.css
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T13:54:47.349Z
+ * Date: 2021-06-10T14:11:19.971Z
  */
 
 .cropper-container {

--- a/dist/cropper.css
+++ b/dist/cropper.css
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-10-08T18:19:48.200Z
+ * Date: 2021-06-09T20:46:05.527Z
  */
 
 .cropper-container {

--- a/dist/cropper.esm.js
+++ b/dist/cropper.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-09T20:46:10.047Z
+ * Date: 2021-06-10T13:54:54.192Z
  */
 
 function _typeof(obj) {
@@ -1270,8 +1270,8 @@ var render = {
 
     var canvasData = {
       aspectRatio: aspectRatio,
-      naturalWidth: naturalWidth,
-      naturalHeight: naturalHeight,
+      naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
+      naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
       width: canvasWidth,
       height: canvasHeight
     };
@@ -1378,10 +1378,7 @@ var render = {
   },
   renderCanvas: function renderCanvas(changed, transformed) {
     var canvasData = this.canvasData,
-        imageData = this.imageData,
-        options = this.options;
-    var optionAspectRatio = options.aspectRatio,
-        containerHeightAspectRatio = options.containerHeightAspectRatio;
+        imageData = this.imageData;
 
     if (transformed) {
       var _getRotatedSizes = getRotatedSizes({
@@ -1398,7 +1395,7 @@ var render = {
       canvasData.top -= (height - canvasData.height) / 2;
       canvasData.width = width;
       canvasData.height = height;
-      canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
+      canvasData.aspectRatio = naturalWidth / naturalHeight;
       canvasData.naturalWidth = naturalWidth;
       canvasData.naturalHeight = naturalHeight;
       this.limitCanvas(true, false);

--- a/dist/cropper.esm.js
+++ b/dist/cropper.esm.js
@@ -1,11 +1,11 @@
 /*!
- * Cropper.js v1.5.9
+ * Cropper.js v1.5.10
  * https://fengyuanchen.github.io/cropperjs
  *
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-09-10T13:16:26.743Z
+ * Date: 2020-10-19T21:08:46.621Z
  */
 
 function _typeof(obj) {
@@ -1221,13 +1221,17 @@ var render = {
         options = this.options,
         container = this.container,
         cropper = this.cropper;
+    var aspectRatio = options.aspectRatio,
+        containerHeightAspectRatio = options.containerHeightAspectRatio;
     var minWidth = Number(options.minContainerWidth);
     var minHeight = Number(options.minContainerHeight);
+    var heightAspectRatio = containerHeightAspectRatio === 'auto' ? aspectRatio : containerHeightAspectRatio;
     addClass(cropper, CLASS_HIDDEN);
     removeClass(element, CLASS_HIDDEN);
+    var containerWidth = Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH);
     var containerData = {
-      width: Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH),
-      height: Math.max(container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
+      width: containerWidth,
+      height: Math.max(heightAspectRatio ? containerWidth / heightAspectRatio : container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
     };
     this.containerData = containerData;
     setStyle(cropper, {
@@ -3332,9 +3336,10 @@ var Cropper = /*#__PURE__*/function () {
 
       if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin) {
         url = addTimestamp(url);
-      }
+      } // The third parameter is required for avoiding side-effect (#682)
 
-      xhr.open('GET', url);
+
+      xhr.open('GET', url, true);
       xhr.responseType = 'arraybuffer';
       xhr.withCredentials = element.crossOrigin === 'use-credentials';
       xhr.send();

--- a/dist/cropper.esm.js
+++ b/dist/cropper.esm.js
@@ -1245,11 +1245,14 @@ var render = {
   initCanvas: function initCanvas() {
     var containerData = this.containerData,
         imageData = this.imageData;
-    var viewMode = this.options.viewMode;
+    var _this$options = this.options,
+        viewMode = _this$options.viewMode,
+        optionAspectRatio = _this$options.aspectRatio,
+        containerHeightAspectRatio = _this$options.containerHeightAspectRatio;
     var rotated = Math.abs(imageData.rotate) % 180 === 90;
     var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
     var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-    var aspectRatio = naturalWidth / naturalHeight;
+    var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
     var canvasWidth = containerData.width;
     var canvasHeight = containerData.height;
 

--- a/dist/cropper.esm.js
+++ b/dist/cropper.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-10-19T21:08:46.621Z
+ * Date: 2021-06-09T20:46:10.047Z
  */
 
 function _typeof(obj) {
@@ -1378,7 +1378,10 @@ var render = {
   },
   renderCanvas: function renderCanvas(changed, transformed) {
     var canvasData = this.canvasData,
-        imageData = this.imageData;
+        imageData = this.imageData,
+        options = this.options;
+    var optionAspectRatio = options.aspectRatio,
+        containerHeightAspectRatio = options.containerHeightAspectRatio;
 
     if (transformed) {
       var _getRotatedSizes = getRotatedSizes({
@@ -1395,7 +1398,7 @@ var render = {
       canvasData.top -= (height - canvasData.height) / 2;
       canvasData.width = width;
       canvasData.height = height;
-      canvasData.aspectRatio = naturalWidth / naturalHeight;
+      canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
       canvasData.naturalWidth = naturalWidth;
       canvasData.naturalHeight = naturalHeight;
       this.limitCanvas(true, false);

--- a/dist/cropper.esm.js
+++ b/dist/cropper.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T13:54:54.192Z
+ * Date: 2021-06-10T14:11:23.958Z
  */
 
 function _typeof(obj) {
@@ -1270,8 +1270,8 @@ var render = {
 
     var canvasData = {
       aspectRatio: aspectRatio,
-      naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
-      naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
+      naturalWidth: naturalWidth,
+      naturalHeight: naturalHeight,
       width: canvasWidth,
       height: canvasHeight
     };

--- a/dist/cropper.esm.js
+++ b/dist/cropper.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T14:11:23.958Z
+ * Date: 2021-08-30T19:53:23.812Z
  */
 
 function _typeof(obj) {
@@ -1252,9 +1252,13 @@ var render = {
     var rotated = Math.abs(imageData.rotate) % 180 === 90;
     var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
     var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-    var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
     var canvasWidth = containerData.width;
     var canvasHeight = containerData.height;
+    var aspectRatio = naturalWidth / naturalHeight;
+
+    if (viewMode === 0 && containerHeightAspectRatio === 'auto') {
+      aspectRatio = optionAspectRatio;
+    }
 
     if (containerData.height * aspectRatio > containerData.width) {
       if (viewMode === 3) {

--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -1251,11 +1251,14 @@
     initCanvas: function initCanvas() {
       var containerData = this.containerData,
           imageData = this.imageData;
-      var viewMode = this.options.viewMode;
+      var _this$options = this.options,
+          viewMode = _this$options.viewMode,
+          optionAspectRatio = _this$options.aspectRatio,
+          containerHeightAspectRatio = _this$options.containerHeightAspectRatio;
       var rotated = Math.abs(imageData.rotate) % 180 === 90;
       var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
       var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-      var aspectRatio = naturalWidth / naturalHeight;
+      var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
       var canvasWidth = containerData.width;
       var canvasHeight = containerData.height;
 

--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -1,11 +1,11 @@
 /*!
- * Cropper.js v1.5.9
+ * Cropper.js v1.5.10
  * https://fengyuanchen.github.io/cropperjs
  *
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-09-10T13:16:26.743Z
+ * Date: 2020-10-19T21:08:46.621Z
  */
 
 (function (global, factory) {
@@ -1227,13 +1227,17 @@
           options = this.options,
           container = this.container,
           cropper = this.cropper;
+      var aspectRatio = options.aspectRatio,
+          containerHeightAspectRatio = options.containerHeightAspectRatio;
       var minWidth = Number(options.minContainerWidth);
       var minHeight = Number(options.minContainerHeight);
+      var heightAspectRatio = containerHeightAspectRatio === 'auto' ? aspectRatio : containerHeightAspectRatio;
       addClass(cropper, CLASS_HIDDEN);
       removeClass(element, CLASS_HIDDEN);
+      var containerWidth = Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH);
       var containerData = {
-        width: Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH),
-        height: Math.max(container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
+        width: containerWidth,
+        height: Math.max(heightAspectRatio ? containerWidth / heightAspectRatio : container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
       };
       this.containerData = containerData;
       setStyle(cropper, {
@@ -3338,9 +3342,10 @@
 
         if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin) {
           url = addTimestamp(url);
-        }
+        } // The third parameter is required for avoiding side-effect (#682)
 
-        xhr.open('GET', url);
+
+        xhr.open('GET', url, true);
         xhr.responseType = 'arraybuffer';
         xhr.withCredentials = element.crossOrigin === 'use-credentials';
         xhr.send();

--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-09T20:46:10.047Z
+ * Date: 2021-06-10T13:54:54.192Z
  */
 
 (function (global, factory) {
@@ -1276,8 +1276,8 @@
 
       var canvasData = {
         aspectRatio: aspectRatio,
-        naturalWidth: naturalWidth,
-        naturalHeight: naturalHeight,
+        naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
+        naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
         width: canvasWidth,
         height: canvasHeight
       };
@@ -1384,10 +1384,7 @@
     },
     renderCanvas: function renderCanvas(changed, transformed) {
       var canvasData = this.canvasData,
-          imageData = this.imageData,
-          options = this.options;
-      var optionAspectRatio = options.aspectRatio,
-          containerHeightAspectRatio = options.containerHeightAspectRatio;
+          imageData = this.imageData;
 
       if (transformed) {
         var _getRotatedSizes = getRotatedSizes({
@@ -1404,7 +1401,7 @@
         canvasData.top -= (height - canvasData.height) / 2;
         canvasData.width = width;
         canvasData.height = height;
-        canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
+        canvasData.aspectRatio = naturalWidth / naturalHeight;
         canvasData.naturalWidth = naturalWidth;
         canvasData.naturalHeight = naturalHeight;
         this.limitCanvas(true, false);

--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T13:54:54.192Z
+ * Date: 2021-06-10T14:11:23.958Z
  */
 
 (function (global, factory) {
@@ -1276,8 +1276,8 @@
 
       var canvasData = {
         aspectRatio: aspectRatio,
-        naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
-        naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
+        naturalWidth: naturalWidth,
+        naturalHeight: naturalHeight,
         width: canvasWidth,
         height: canvasHeight
       };

--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T14:11:23.958Z
+ * Date: 2021-08-30T19:53:23.812Z
  */
 
 (function (global, factory) {
@@ -1258,9 +1258,13 @@
       var rotated = Math.abs(imageData.rotate) % 180 === 90;
       var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
       var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-      var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
       var canvasWidth = containerData.width;
       var canvasHeight = containerData.height;
+      var aspectRatio = naturalWidth / naturalHeight;
+
+      if (viewMode === 0 && containerHeightAspectRatio === 'auto') {
+        aspectRatio = optionAspectRatio;
+      }
 
       if (containerData.height * aspectRatio > containerData.width) {
         if (viewMode === 3) {

--- a/dist/cropper.js
+++ b/dist/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-10-19T21:08:46.621Z
+ * Date: 2021-06-09T20:46:10.047Z
  */
 
 (function (global, factory) {
@@ -1384,7 +1384,10 @@
     },
     renderCanvas: function renderCanvas(changed, transformed) {
       var canvasData = this.canvasData,
-          imageData = this.imageData;
+          imageData = this.imageData,
+          options = this.options;
+      var optionAspectRatio = options.aspectRatio,
+          containerHeightAspectRatio = options.containerHeightAspectRatio;
 
       if (transformed) {
         var _getRotatedSizes = getRotatedSizes({
@@ -1401,7 +1404,7 @@
         canvasData.top -= (height - canvasData.height) / 2;
         canvasData.width = width;
         canvasData.height = height;
-        canvasData.aspectRatio = naturalWidth / naturalHeight;
+        canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
         canvasData.naturalWidth = naturalWidth;
         canvasData.naturalHeight = naturalHeight;
         this.limitCanvas(true, false);

--- a/docs/js/cropper.js
+++ b/docs/js/cropper.js
@@ -1,11 +1,11 @@
 /*!
- * Cropper.js v1.5.9
+ * Cropper.js v1.5.10
  * https://fengyuanchen.github.io/cropperjs
  *
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-09-10T13:16:26.743Z
+ * Date: 2020-10-19T21:08:46.621Z
  */
 
 (function (global, factory) {
@@ -1227,13 +1227,17 @@
           options = this.options,
           container = this.container,
           cropper = this.cropper;
+      var aspectRatio = options.aspectRatio,
+          containerHeightAspectRatio = options.containerHeightAspectRatio;
       var minWidth = Number(options.minContainerWidth);
       var minHeight = Number(options.minContainerHeight);
+      var heightAspectRatio = containerHeightAspectRatio === 'auto' ? aspectRatio : containerHeightAspectRatio;
       addClass(cropper, CLASS_HIDDEN);
       removeClass(element, CLASS_HIDDEN);
+      var containerWidth = Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH);
       var containerData = {
-        width: Math.max(container.offsetWidth, minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH),
-        height: Math.max(container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
+        width: containerWidth,
+        height: Math.max(heightAspectRatio ? containerWidth / heightAspectRatio : container.offsetHeight, minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT)
       };
       this.containerData = containerData;
       setStyle(cropper, {
@@ -3338,9 +3342,10 @@
 
         if (options.checkCrossOrigin && isCrossOriginURL(url) && element.crossOrigin) {
           url = addTimestamp(url);
-        }
+        } // The third parameter is required for avoiding side-effect (#682)
 
-        xhr.open('GET', url);
+
+        xhr.open('GET', url, true);
         xhr.responseType = 'arraybuffer';
         xhr.withCredentials = element.crossOrigin === 'use-credentials';
         xhr.send();

--- a/docs/js/cropper.js
+++ b/docs/js/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-09T20:46:10.047Z
+ * Date: 2021-06-10T13:54:54.192Z
  */
 
 (function (global, factory) {
@@ -1276,8 +1276,8 @@
 
       var canvasData = {
         aspectRatio: aspectRatio,
-        naturalWidth: naturalWidth,
-        naturalHeight: naturalHeight,
+        naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
+        naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
         width: canvasWidth,
         height: canvasHeight
       };
@@ -1384,10 +1384,7 @@
     },
     renderCanvas: function renderCanvas(changed, transformed) {
       var canvasData = this.canvasData,
-          imageData = this.imageData,
-          options = this.options;
-      var optionAspectRatio = options.aspectRatio,
-          containerHeightAspectRatio = options.containerHeightAspectRatio;
+          imageData = this.imageData;
 
       if (transformed) {
         var _getRotatedSizes = getRotatedSizes({
@@ -1404,7 +1401,7 @@
         canvasData.top -= (height - canvasData.height) / 2;
         canvasData.width = width;
         canvasData.height = height;
-        canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
+        canvasData.aspectRatio = naturalWidth / naturalHeight;
         canvasData.naturalWidth = naturalWidth;
         canvasData.naturalHeight = naturalHeight;
         this.limitCanvas(true, false);

--- a/docs/js/cropper.js
+++ b/docs/js/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-10-19T21:08:46.621Z
+ * Date: 2021-06-09T20:46:10.047Z
  */
 
 (function (global, factory) {
@@ -1251,11 +1251,14 @@
     initCanvas: function initCanvas() {
       var containerData = this.containerData,
           imageData = this.imageData;
-      var viewMode = this.options.viewMode;
+      var _this$options = this.options,
+          viewMode = _this$options.viewMode,
+          optionAspectRatio = _this$options.aspectRatio,
+          containerHeightAspectRatio = _this$options.containerHeightAspectRatio;
       var rotated = Math.abs(imageData.rotate) % 180 === 90;
       var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
       var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-      var aspectRatio = naturalWidth / naturalHeight;
+      var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
       var canvasWidth = containerData.width;
       var canvasHeight = containerData.height;
 
@@ -1381,7 +1384,10 @@
     },
     renderCanvas: function renderCanvas(changed, transformed) {
       var canvasData = this.canvasData,
-          imageData = this.imageData;
+          imageData = this.imageData,
+          options = this.options;
+      var optionAspectRatio = options.aspectRatio,
+          containerHeightAspectRatio = options.containerHeightAspectRatio;
 
       if (transformed) {
         var _getRotatedSizes = getRotatedSizes({
@@ -1398,7 +1404,7 @@
         canvasData.top -= (height - canvasData.height) / 2;
         canvasData.width = width;
         canvasData.height = height;
-        canvasData.aspectRatio = naturalWidth / naturalHeight;
+        canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
         canvasData.naturalWidth = naturalWidth;
         canvasData.naturalHeight = naturalHeight;
         this.limitCanvas(true, false);

--- a/docs/js/cropper.js
+++ b/docs/js/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T13:54:54.192Z
+ * Date: 2021-06-10T14:11:23.958Z
  */
 
 (function (global, factory) {
@@ -1276,8 +1276,8 @@
 
       var canvasData = {
         aspectRatio: aspectRatio,
-        naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
-        naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
+        naturalWidth: naturalWidth,
+        naturalHeight: naturalHeight,
         width: canvasWidth,
         height: canvasHeight
       };

--- a/docs/js/cropper.js
+++ b/docs/js/cropper.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2021-06-10T14:11:23.958Z
+ * Date: 2021-08-30T19:53:23.812Z
  */
 
 (function (global, factory) {
@@ -1258,9 +1258,13 @@
       var rotated = Math.abs(imageData.rotate) % 180 === 90;
       var naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
       var naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-      var aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : naturalWidth / naturalHeight;
       var canvasWidth = containerData.width;
       var canvasHeight = containerData.height;
+      var aspectRatio = naturalWidth / naturalHeight;
+
+      if (viewMode === 0 && containerHeightAspectRatio === 'auto') {
+        aspectRatio = optionAspectRatio;
+      }
 
       if (containerData.height * aspectRatio > containerData.width) {
         if (viewMode === 3) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cropperjs",
   "description": "JavaScript image cropper.",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "main": "dist/cropper.common.js",
   "module": "dist/cropper.esm.js",
   "browser": "dist/cropper.js",

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -72,11 +72,11 @@ export default {
   // Canvas (image wrapper)
   initCanvas() {
     const { containerData, imageData } = this;
-    const { viewMode } = this.options;
+    const { viewMode, aspectRatio: optionAspectRatio, containerHeightAspectRatio } = this.options;
     const rotated = Math.abs(imageData.rotate) % 180 === 90;
     const naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
     const naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-    const aspectRatio = naturalWidth / naturalHeight;
+    const aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : (naturalWidth / naturalHeight);
     let canvasWidth = containerData.width;
     let canvasHeight = containerData.height;
 

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -223,7 +223,8 @@ export default {
   },
 
   renderCanvas(changed, transformed) {
-    const { canvasData, imageData } = this;
+    const { canvasData, imageData, options } = this;
+    const { aspectRatio: optionAspectRatio, containerHeightAspectRatio } = options;
 
     if (transformed) {
       const { width: naturalWidth, height: naturalHeight } = getRotatedSizes({
@@ -238,7 +239,7 @@ export default {
       canvasData.top -= (height - canvasData.height) / 2;
       canvasData.width = width;
       canvasData.height = height;
-      canvasData.aspectRatio = naturalWidth / naturalHeight;
+      canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : (naturalWidth / naturalHeight);
       canvasData.naturalWidth = naturalWidth;
       canvasData.naturalHeight = naturalHeight;
       this.limitCanvas(true, false);

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -94,8 +94,8 @@ export default {
 
     const canvasData = {
       aspectRatio,
-      naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
-      naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
+      naturalWidth,
+      naturalHeight,
       width: canvasWidth,
       height: canvasHeight,
     };

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -38,19 +38,22 @@ export default {
       container,
       cropper,
     } = this;
+    const { aspectRatio, containerHeightAspectRatio } = options;
     const minWidth = Number(options.minContainerWidth);
     const minHeight = Number(options.minContainerHeight);
+    const heightAspectRatio = containerHeightAspectRatio === 'auto' ? aspectRatio : containerHeightAspectRatio;
 
     addClass(cropper, CLASS_HIDDEN);
     removeClass(element, CLASS_HIDDEN);
 
+    const containerWidth = Math.max(
+      container.offsetWidth,
+      minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH,
+    );
     const containerData = {
-      width: Math.max(
-        container.offsetWidth,
-        minWidth >= 0 ? minWidth : MIN_CONTAINER_WIDTH,
-      ),
+      width: containerWidth,
       height: Math.max(
-        container.offsetHeight,
+        heightAspectRatio ? (containerWidth / heightAspectRatio) : container.offsetHeight,
         minHeight >= 0 ? minHeight : MIN_CONTAINER_HEIGHT,
       ),
     };

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -94,8 +94,8 @@ export default {
 
     const canvasData = {
       aspectRatio,
-      naturalWidth,
-      naturalHeight,
+      naturalWidth: containerHeightAspectRatio === 'auto' ? canvasWidth : naturalWidth,
+      naturalHeight: containerHeightAspectRatio === 'auto' ? canvasHeight : naturalHeight,
       width: canvasWidth,
       height: canvasHeight,
     };
@@ -223,8 +223,7 @@ export default {
   },
 
   renderCanvas(changed, transformed) {
-    const { canvasData, imageData, options } = this;
-    const { aspectRatio: optionAspectRatio, containerHeightAspectRatio } = options;
+    const { canvasData, imageData } = this;
 
     if (transformed) {
       const { width: naturalWidth, height: naturalHeight } = getRotatedSizes({
@@ -239,7 +238,7 @@ export default {
       canvasData.top -= (height - canvasData.height) / 2;
       canvasData.width = width;
       canvasData.height = height;
-      canvasData.aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : (naturalWidth / naturalHeight);
+      canvasData.aspectRatio = naturalWidth / naturalHeight;
       canvasData.naturalWidth = naturalWidth;
       canvasData.naturalHeight = naturalHeight;
       this.limitCanvas(true, false);

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -76,9 +76,13 @@ export default {
     const rotated = Math.abs(imageData.rotate) % 180 === 90;
     const naturalWidth = rotated ? imageData.naturalHeight : imageData.naturalWidth;
     const naturalHeight = rotated ? imageData.naturalWidth : imageData.naturalHeight;
-    const aspectRatio = containerHeightAspectRatio === 'auto' ? optionAspectRatio : (naturalWidth / naturalHeight);
     let canvasWidth = containerData.width;
     let canvasHeight = containerData.height;
+
+    let aspectRatio = naturalWidth / naturalHeight;
+    if (viewMode === 0 && containerHeightAspectRatio === 'auto') {
+      aspectRatio = optionAspectRatio;
+    }
 
     if (containerData.height * aspectRatio > containerData.width) {
       if (viewMode === 3) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -125,6 +125,7 @@ declare namespace Cropper {
     center?: boolean;
     checkCrossOrigin?: boolean;
     checkOrientation?: boolean;
+    containerHeightAspectRatio?: number | 'auto';
     cropBoxMovable?: boolean;
     cropBoxResizable?: boolean;
     data?: Data;


### PR DESCRIPTION
**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [x ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
My use case, I have a placeholder for cropper, what has absolute position in percentages. v1.5.9 fit the cropper container to the width, bud height is not calculate properly and it is derived from the image. But I need keep same placeholder ratio without any dependency and size of viewport. So I add possibility to set this ratio and it works great. Usage is optional, of course.
