### PR TITLE
test: make `wheelZoomRatio` test check less strict (round up to tenths)

### DIFF
--- a/test/specs/options/wheelZoomRatio.spec.js
+++ b/test/specs/options/wheelZoomRatio.spec.js
@@ -28,7 +28,13 @@ describe('wheelZoomRatio (option)', () => {
 
         wheelEvent.deltaY = -1;
         cropper.cropper.dispatchEvent(wheelEvent);
-        expect(canvasData.width * (1 + wheelZoomRatio)).to.equal(cropper.getCanvasData().width);
+        const expectedWidthRaw = canvasData.width * (1 + wheelZoomRatio);
+        const actualWidthRaw = cropper.getCanvasData().width;
+
+        const expectedWidth = Math.round(expectedWidthRaw * 10) / 10;
+        const actualWidth = Math.round(actualWidthRaw * 10) / 10;
+
+        expect(expectedWidth).to.equal(actualWidth);
         done();
       },
     });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [x] Other, please describe: fixing tests for particular environment

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Wanted to play with the lib and to check some ideas. Simple `npm run test` on `master` failed on me in minor way and for obscure reason. Seems like something related to my Windows 10 \ Cygwin environment:

<img src="https://user-images.githubusercontent.com/3756009/113478079-3546d200-948f-11eb-81c9-d120c1e0e9db.png" width="600">

Slight rounding like the one I propose (up to tenths) should fix that and not ruin the test strictness too much.
