### PR TITLE
fix: Remove side effects from cropper inside modal example

### DIFF
--- a/docs/examples/upload-cropped-image-to-server.html
+++ b/docs/examples/upload-cropped-image-to-server.html
@@ -103,12 +103,12 @@
         }
       });
 
-      $modal.on('shown.bs.modal', function () {
+      $modal.off('shown.bs.modal').on('shown.bs.modal', function () {
         cropper = new Cropper(image, {
           aspectRatio: 1,
           viewMode: 3,
         });
-      }).on('hidden.bs.modal', function () {
+      }).off('hidden.bs.modal').on('hidden.bs.modal', function () {
         cropper.destroy();
         cropper = null;
       });


### PR DESCRIPTION
Every time the modal opens, it creates a new instance of the Cropper, which renders some inconsistent behavior if the modal is launched multiple times. Solution is to remove the event listener before adding the new listener when the modal is opened.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
