### PR TITLE
fix: example for round image on iOS/Safari

### DIFF
--- a/docs/examples/crop-a-round-image.html
+++ b/docs/examples/crop-a-round-image.html
@@ -20,6 +20,11 @@
     .cropper-face {
       border-radius: 50%;
     }
+
+    .cropper-view-box {
+        outline: 0;
+        box-shadow: 0 0 0 1px #39f;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

# Summary

Because of an old [bug](https://bugs.webkit.org/show_bug.cgi?id=20807) the css styles for `outline` do not follow `border-radius` on iOS/Safari. The example "crop-a-round-image.html" would show a rectangular crop box in browsers with this bug.

I fixed it, following the approach that is also suggested in issue [#545](https://github.com/fengyuanchen/cropper/issues/545).

## Images (iOS/Safari vs. Firefox)

![bug_cropper js_border-radius](https://user-images.githubusercontent.com/5956390/187967095-4ab07aaf-3b25-4d51-93b0-2bca3f1a21a5.jpg)

![bug_cropper js_border-radius_firefox](https://user-images.githubusercontent.com/5956390/187967432-714d5e06-f03a-4ed2-8ed2-a10777278c70.png)

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [x] Firefox 104.0.1 (64-bit)
- [x] Safari
- [x] Edge 104.0.1293.70 (Official build) (64-bit)
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
