### PR TITLE
iOS Chrome: Long press on .cropper-container triggers unexpected behavior

### DIFF
--- a/docs/css/cropper.css
+++ b/docs/css/cropper.css
@@ -19,6 +19,7 @@
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  -webkit-touch-callout: none;
 }
 
 .cropper-container img {


### PR DESCRIPTION
**Summary**
On iOS Chrome, after long-pressing on the cropper container area which makes the context menu pop up, only the pan gesture can be recognized, and other gestures don't work. And the pan gesture now only scales the image instead of moving it like it was. You can see it in the video below.

https://github.com/fengyuanchen/cropperjs/assets/46563912/b84279f5-b01c-4620-9343-4715fd5dacad


Right now, the solution we found is adding "-webkit-touch-callout: none;" to the ".cropper-container" class selector.

If you'd like to apply this change, please review my pull request and merge it if there are no problems. Thanks!
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
