### PR TITLE
feat(cropperjs): exports `DEFAULT_TEMPLATE`

### DIFF
--- a/packages/cropperjs/src/index.ts
+++ b/packages/cropperjs/src/index.ts
@@ -17,6 +17,8 @@ import {
 } from '@cropper/elements';
 import DEFAULT_TEMPLATE from './template';
 
+export { DEFAULT_TEMPLATE }
+
 export interface CropperOptions {
   container?: Element | string;
   template?: string;


### PR DESCRIPTION
Allowing client to referrence/import the default template and maybe make modifications and feed to `template` param.

Currently the client have no way no know(?) what is the default template if leave undefined.

Not yet tested but is only an export statement. (Sorry didn't have time + no document to setup development on v2)

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
