### PR TITLE
feat(cropper-selection): aspectRatio reactivity

### DIFF
--- a/packages/element-selection/src/index.ts
+++ b/packages/element-selection/src/index.ts
@@ -138,6 +138,7 @@ export default class CropperSelection extends CropperElement {
         if (!isPositiveNumber(newValue)) {
           this.aspectRatio = NaN;
         }
+        this.$change(this.x, this.y)
         break;
 
       case 'initialAspectRatio':
@@ -844,16 +845,16 @@ export default class CropperSelection extends CropperElement {
       height = Math.round(height);
     }
 
+    if (isPositiveNumber(aspectRatio)) {
+      ({ width, height } = getAdjustedSizes({ aspectRatio, width, height }, 'cover'));
+    }
+
     if (x === this.x && y === this.y && width === this.width && height === this.height) {
       return this;
     }
 
     if (this.hidden) {
       this.hidden = false;
-    }
-
-    if (isPositiveNumber(aspectRatio)) {
-      ({ width, height } = getAdjustedSizes({ aspectRatio, width, height }, 'cover'));
     }
 
     if (this.$emit(EVENT_CHANGE, {


### PR DESCRIPTION
Reopen of #1161 

Resolves #1124

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)
Maybe?, theorically if user allowed input to change the aspect-ratio multiple times before commiting an action, then previously the width/height is only recalculated once, but because it is now reactive, the width/height would recalculated and grow multiple times.
#1164 would improve the UX on this part where the selection area would not grow too much.

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
It is referenced in commit body

You have tested in the following browsers: (Providing a detailed version will be better.)
Tested with playground

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
