### PR TITLE
feat(cropper-selection): uses `getAdjustedSizesKeepArea()` for aspectRatio calculation

### DIFF
--- a/packages/element-selection/src/index.ts
+++ b/packages/element-selection/src/index.ts
@@ -22,6 +22,7 @@ import {
   EVENT_CHANGE,
   EVENT_KEYDOWN,
   getAdjustedSizes,
+  getAdjustedSizesKeepArea,
   getOffset,
   isFunction,
   isNumber,
@@ -853,7 +854,7 @@ export default class CropperSelection extends CropperElement {
     }
 
     if (isPositiveNumber(aspectRatio)) {
-      ({ width, height } = getAdjustedSizes({ aspectRatio, width, height }, 'cover'));
+      ({ width, height } = getAdjustedSizesKeepArea({ aspectRatio, width, height }));
     }
 
     if (this.$emit(EVENT_CHANGE, {

--- a/packages/utils/src/functions.ts
+++ b/packages/utils/src/functions.ts
@@ -323,6 +323,25 @@ export function getAdjustedSizes(
 }
 
 /**
+ * Get the new width and height sizes based on given aspect ratio.
+ * @param {object} data The original sizes, with maybe a new aspect ratio.
+ * @returns {object} Returns the result sizes.
+ */
+export function getAdjustedSizesKeepArea(
+  data: SizeAdjustmentData,
+) {
+  const { aspectRatio } = data;
+  let { width, height } = data;
+
+  const area = width * height;
+
+  height = Math.sqrt(area / aspectRatio);
+  width = aspectRatio * height;
+
+  return { width: width, height: height };
+}
+
+/**
  * Multiply multiple matrices.
  * @param {Array} matrix The first matrix.
  * @param {Array} args The rest matrices.


### PR DESCRIPTION
Reopen of #1162

Previously we grow the width/height to fit with the new aspect-ratio.

This PR changes the calculation: now we changes both the width and height while keeping the original area, which in theory would fit a better UX, especially when take in account of (#1163 aspect-ratio reactivity)

Without this PR, #1163 would behave as follow: the selection area being grown out of view when input changes, especially for dynamic user inputted usage.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)
There is a behavior change, is breaking.

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
