### PR TITLE
fix: regex expressions - anchors not being respected

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -57,10 +57,10 @@ export const EVENT_ZOOM = 'zoom';
 export const MIME_TYPE_JPEG = 'image/jpeg';
 
 // RegExps
-export const REGEXP_ACTIONS = /^e|w|s|n|se|sw|ne|nw|all|crop|move|zoom$/;
+export const REGEXP_ACTIONS = /^(e|w|s|n|se|sw|ne|nw|all|crop|move|zoom)$/;
 export const REGEXP_DATA_URL = /^data:/;
 export const REGEXP_DATA_URL_JPEG = /^data:image\/jpeg;base64,/;
-export const REGEXP_TAG_NAME = /^img|canvas$/i;
+export const REGEXP_TAG_NAME = /^(img|canvas)$/i;
 
 // Misc
 // Inspired by the default width and height of a canvas element.


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Regexs like `/^a|b|c$/` match `a` at start of text, `c` at end of text, or `b`.  I assume this does not match the original intent.

This moves the union into a capture group so `^` and `$` are respected for the whole union and not just a couple members of the union.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

![image](https://github.com/user-attachments/assets/177c03b3-ba2f-4975-985d-bf72737b4b76)

