### PR TITLE
fix #1078 Prevent shade from "glitching" when pulling selection too far

### DIFF
--- a/packages/element-shade/src/index.ts
+++ b/packages/element-shade/src/index.ts
@@ -85,12 +85,10 @@ export default class CropperShade extends CropperElement {
           }
         };
         this.$onCanvasChange = (event) => {
-          const {
-            x,
-            y,
-            width,
-            height,
-          } = (event as CustomEvent).detail;
+          const x = $selection.x;
+          const y = $selection.y;
+          const width = $selection.width;
+          const height = $selection.height;
 
           this.$change(x, y, width, height);
 

--- a/packages/element-shade/src/index.ts
+++ b/packages/element-shade/src/index.ts
@@ -84,11 +84,13 @@ export default class CropperShade extends CropperElement {
             this.hidden = true;
           }
         };
-        this.$onCanvasChange = (event) => {
-          const x = $selection.x;
-          const y = $selection.y;
-          const width = $selection.width;
-          const height = $selection.height;
+        this.$onCanvasChange = () => {
+          const {
+            x,
+            y,
+            width,
+            height,
+          } = $selection;
 
           this.$change(x, y, width, height);
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

As complained by [Issue #1078](https://github.com/fengyuanchen/cropperjs/issues/1078), the shade has a glitching offset effect if using the method to restrain the selection pointed out in the documentation. This change aims to eliminate that by directly tying the shade to the selection instead of the change event.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
