### PR TITLE
fix: set crossorigin attribute on cropper image element

### DIFF
--- a/packages/cropperjs/src/index.ts
+++ b/packages/cropperjs/src/index.ts
@@ -109,6 +109,9 @@ export default class Cropper {
       Array.from(documentFragment.querySelectorAll(CROPPER_IMAGE)).forEach((image) => {
         image.setAttribute('src', src);
         image.setAttribute('alt', (element as HTMLImageElement).alt || 'The image to crop');
+        if (element instanceof HTMLImageElement && typeof element.crossOrigin === 'string') {
+          image.setAttribute('crossorigin', element.crossOrigin);
+        }
       });
 
       if (element.parentElement) {

--- a/packages/cropperjs/tests/index.spec.ts
+++ b/packages/cropperjs/tests/index.spec.ts
@@ -1,5 +1,6 @@
 import {
   CROPPER_CANVAS,
+  CROPPER_IMAGE,
 } from '@cropper/utils';
 import {
   CropperCanvas,
@@ -86,6 +87,30 @@ describe('Cropper', () => {
         expect(cropper.options.template).toBe(template);
         expect(document.querySelector('#cropperCanvas')).toBeTruthy();
       });
+
+      it('should set crossorigin attribute on image', () => {
+        const image = new Image();
+        image.crossOrigin = '';
+        const cropper = new Cropper(image);
+
+        expect(cropper.options.template).toBeDefined();
+      });
+    });
+  });
+
+  describe('others', () => {
+    it('should inherit alt and crossorigin', () => {
+      const image = new Image();
+      image.crossOrigin = 'anonymous';
+      image.alt = 'Test alt text';
+      new Cropper(image);
+
+      const element = document.querySelector(CROPPER_IMAGE);
+
+      if (element) {
+        expect(element.hasAttribute('alt')).toBe(true);
+        expect(element.hasAttribute('crossorigin')).toBe(true);
+      }
     });
   });
 

--- a/packages/cropperjs/tests/index.spec.ts
+++ b/packages/cropperjs/tests/index.spec.ts
@@ -87,14 +87,6 @@ describe('Cropper', () => {
         expect(cropper.options.template).toBe(template);
         expect(document.querySelector('#cropperCanvas')).toBeTruthy();
       });
-
-      it('should set crossorigin attribute on image', () => {
-        const image = new Image();
-        image.crossOrigin = '';
-        const cropper = new Cropper(image);
-
-        expect(cropper.options.template).toBeDefined();
-      });
     });
   });
 


### PR DESCRIPTION
New image element does the cross origin call to avoid canvas being tainted

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

The crossorigin attribute of the passing image will be passed through the underlying cropper-image element. Before, the image request would not use cors mode while it will now.

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
