### PR TITLE
fix: correct require.node.default export and explicitly export package.json

### DIFF
--- a/packages/cropperjs/package.json
+++ b/packages/cropperjs/package.json
@@ -30,7 +30,8 @@
         },
         "default": "./dist/cropper.raw.js"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "api-extractor": "api-extractor run --local --verbose",

--- a/packages/cropperjs/package.json
+++ b/packages/cropperjs/package.json
@@ -26,7 +26,7 @@
         "node": {
           "production": "./dist/cropper.min.js",
           "development": "./dist/cropper.js",
-          "default": "./cropper.raw.js"
+          "default": "./dist/cropper.raw.js"
         },
         "default": "./dist/cropper.raw.js"
       }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Part of a project I'm working on calls `require.resolve('cropperjs')` to retrieve the path of CropperJS. It does the same for the other Node modules in my project. 

However, the CropperJS `package.json` `require.node.default` link points to `./cropper.raw.js`, which does not exist. 

https://github.com/fengyuanchen/cropperjs/blob/91d5ab3b3637a20d710eeeab6d6353ce0db4a85f/packages/cropperjs/package.json#L24-L32

![Screenshot 2025-07-02 at 3 50 07 PM](https://github.com/user-attachments/assets/c2c58e88-7cc4-4e86-8833-e127f9f2bd91)

As a result, calling `require.resolve('cropperjs')` throws an error:

![image](https://github.com/user-attachments/assets/312ae409-19a7-4e66-9c34-596eca726d93)

Changing this to `./dist/cropper.raw.js` fixes the issue. 

Moreover, I have added `"./package.json": "./package.json"` to the `package.json` `exports` to ensure that `require('cropperjs/package.json')` will resolve correctly, making CropperJS's metadata (version, author, license, etc.) more explicitly available to consumers and tooling.

Demonstration of the issue:

https://github.com/user-attachments/assets/5c2f37d2-afec-4d91-a990-249fc7aeb976

GitHub repository with minimal reproduction:

https://github.com/miguelaenlle/cropper-js-package-path-issue/tree/main

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

I did not test the change on separate browsers, since the issue occurs for me while running NodeJS on the serverside. I ran the full CropperJS test suite, and all tests pass. 

![Screenshot 2025-07-02 at 3 52 20 PM](https://github.com/user-attachments/assets/c988afda-a803-4ed6-8a0b-8492026c0605)

A GitHub repository with a minimal reproduction of this issue is available at https://github.com/miguelaenlle/cropper-js-package-path-issue/tree/main. 