### PR TITLE
fix(element-selection): get correct event target in shadow DOM

### DIFF
--- a/packages/element-selection/src/index.ts
+++ b/packages/element-selection/src/index.ts
@@ -27,6 +27,7 @@ import {
   isNumber,
   isPlainObject,
   isPositiveNumber,
+  getComposedPathTarget,
   off,
   on,
 } from '@cropper/utils';
@@ -395,11 +396,14 @@ export default class CropperSelection extends CropperElement {
 
     const { relatedEvent } = detail;
     let { action } = detail;
+    const relatedTarget = relatedEvent
+      ? getComposedPathTarget(relatedEvent)
+      : null;
 
     // Switching to another selection
     if (!action && this.multiple) {
       // Get the `action` property from the focusing in selection
-      action = this.$action || relatedEvent?.target.action;
+      action = this.$action || (relatedTarget as any)?.action;
       this.$action = action;
     }
 

--- a/packages/utils/src/functions.ts
+++ b/packages/utils/src/functions.ts
@@ -199,6 +199,22 @@ export function emit(
   }));
 }
 
+/**
+ * Get the real event target by checking composed path.
+ * This is useful when dealing with events that can cross shadow DOM boundaries.
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath}
+ * @param {Event} event The event object.
+ * @returns {EventTarget | null} The first element in the composed path, or the original event target.
+ */
+export function getComposedPathTarget(event: Event): EventTarget | null {
+  if (typeof (event as any).composedPath === 'function') {
+    const path = (event as any).composedPath();
+    return path.find(isElement) || event.target;
+  }
+
+  return event.target;
+}
+
 const resolvedPromise: Promise<any> = Promise.resolve();
 
 /**


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**
When using multiple selections under a shadow root, inactive selections cannot be dragged
https://fleeze.github.io/cropperjs_demo/

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 140
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
